### PR TITLE
Use quoted paths for all unix commands

### DIFF
--- a/src/main/java/com/pastdev/jsch/nio/file/AbstractSshPath.java
+++ b/src/main/java/com/pastdev/jsch/nio/file/AbstractSshPath.java
@@ -7,6 +7,21 @@ import java.util.Iterator;
 
 
 abstract public class AbstractSshPath implements Path {
+    public static final String QUOTED_SPECIAL = "\"$";
+
+    static public String protect(String string, String special) {
+        if (string.equals(""))
+            return "\"\"";
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < string.length(); i++) {
+            final char c = string.charAt(i);
+            if (special.indexOf(c) != -1)
+                sb.append("\\");
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+
     private AbstractSshFileSystem fileSystem;
 
     protected AbstractSshPath( AbstractSshFileSystem fileSystem ) {
@@ -59,5 +74,9 @@ abstract public class AbstractSshPath implements Path {
     @Override
     public File toFile() {
         throw new UnsupportedOperationException( "path not from default provider" );
+    }
+
+    public String quotedString() {
+        return '"' + protect(toString(), QUOTED_SPECIAL) + '"';
     }
 }


### PR DESCRIPTION
I ran into problem with a filename containing a $. I changed the code (I hope all of the occurrences) by a .quotedString() that returns the quoted filename with special characters protected. This would also solve the problem of spaces into files