### PR TITLE
Removed jsch and slf4j from dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,29 +46,18 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    
+
     <bcprov.version>1.51</bcprov.version>
-    <jsch.version>0.1.51</jsch.version>
     <jsch-extension.version>0.1.3</jsch-extension.version>
     <junit.version>4.11</junit.version>
     <logback.version>1.0.13</logback.version>
     <slf4j.version>1.7.7</slf4j.version>
-    
+
     <maven-compiler-plugin.version>3.2</maven-compiler-plugin.version>
     <maven-release-plugin.version>2.5.1</maven-release-plugin.version>
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>com.jcraft</groupId>
-      <artifactId>jsch</artifactId>
-      <version>${jsch.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
-    </dependency>
     <dependency>
       <groupId>com.pastdev</groupId>
       <artifactId>jsch-extension</artifactId>


### PR DESCRIPTION
Since jsch-extension declares the dependencies, no need to declare them in jsch-nio.