### PR TITLE
By default, open in READ mode

### DIFF
--- a/src/main/java/com/pastdev/jsch/nio/file/UnixSshSeekableByteChannel.java
+++ b/src/main/java/com/pastdev/jsch/nio/file/UnixSshSeekableByteChannel.java
@@ -29,7 +29,7 @@ public class UnixSshSeekableByteChannel implements SeekableByteChannel {
     public UnixSshSeekableByteChannel( UnixSshPath path, Set<? extends OpenOption> openOptions, FileAttribute<?>... createFileAttributes ) throws IOException {
         this.path = path.toAbsolutePath();
         this.append = openOptions.contains( StandardOpenOption.APPEND );
-        this.readable = openOptions.contains( StandardOpenOption.READ );
+        this.readable = openOptions.isEmpty() || openOptions.contains( StandardOpenOption.READ );
         this.writeable = openOptions.contains( StandardOpenOption.WRITE );
 
         this.provider = path.getFileSystem().provider();


### PR DESCRIPTION
This is to follow Java documentation ("If no options are present then it is equivalent to opening the file with the `READ` option")