### PR TITLE
Update UnixSshFileSystemProvider.java

### DIFF
--- a/src/main/java/com/pastdev/jsch/nio/file/UnixSshFileSystemProvider.java
+++ b/src/main/java/com/pastdev/jsch/nio/file/UnixSshFileSystemProvider.java
@@ -894,7 +894,13 @@ public class UnixSshFileSystemProvider extends AbstractSshFileSystemProvider {
                 return Long.parseLong( value );
             }
             if ( valueClass == FileTime.class ) {
-                return FileTime.fromMillis( Long.parseLong( value ) * 1000 );
+                long seconds = 0;
+                try {
+                    seconds = Long.parseLong( value );
+                } catch ( NumberFormatException e ) {
+                    //Do nothing. Some stat versions don't support creation date and potentionally other times.
+                }
+                return FileTime.fromMillis( seconds * 1000 );
             }
 
             return value;


### PR DESCRIPTION
Not all versions of stat support creation time. This will handle the case where it returns something other than a number. I've tried with 3 different versions of stat and 2 of them returned something other than a number. In one case it was "W" and in another it was "?". The spec for BasicFileAttributes says that the epoche is a valid default value in case the file system doesn't support the feature.
Instead of dealing with exceptions, you can validate that it's a number using some other means.