### PR TITLE
Update UnixSshFileSystemProvider.java

### DIFF
--- a/src/main/java/com/pastdev/jsch/nio/file/UnixSshFileSystemProvider.java
+++ b/src/main/java/com/pastdev/jsch/nio/file/UnixSshFileSystemProvider.java
@@ -161,7 +161,7 @@ public class UnixSshFileSystemProvider extends AbstractSshFileSystemProvider {
     @Override
     @SuppressWarnings("unchecked")
     public void createDirectory( Path path, FileAttribute<?>... fileAttributes ) throws IOException {
-        UnixSshPath unixPath = checkPath( path );
+        UnixSshPath unixPath = checkPath( path ).toAbsolutePath();
         Set<PosixFilePermission> permissions = null;
         for ( FileAttribute<?> fileAttribute : fileAttributes ) {
             if ( fileAttribute.name().equals( "posix:permissions" ) ) {


### PR DESCRIPTION
Without toAbsolutePath(), this will execute on the root directory. There are probably other places with this problem as well.