### PR TITLE
fix getParent should return null for path as "oneLengthNonAbsolute"

### DIFF
--- a/src/main/java/com/pastdev/jsch/nio/file/UnixSshPath.java
+++ b/src/main/java/com/pastdev/jsch/nio/file/UnixSshPath.java
@@ -150,7 +150,7 @@ public class UnixSshPath extends AbstractSshPath {
     /** {@inheritDoc} */
     @Override
     public UnixSshPath getParent() {
-        if ( parts.length == 0 && !isAbsolute() ) {
+        if ( (parts.length == 0 || parts.length == 1) && !isAbsolute() ) {
             return null;
         }
         if ( parts.length <= 1 ) {


### PR DESCRIPTION
When i tried Files.createTempDirectory(), it did not work.
Path with only one part and not absolute whose parent should be null,