### PR TITLE
change fileKey to BigDecimal to fix parseLong exceptions...

### DIFF
--- a/src/main/java/com/pastdev/jsch/nio/file/UnixSshFileSystemProvider.java
+++ b/src/main/java/com/pastdev/jsch/nio/file/UnixSshFileSystemProvider.java
@@ -4,6 +4,7 @@ package com.pastdev.jsch.nio.file;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.math.BigDecimal;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
@@ -829,7 +830,7 @@ public class UnixSshFileSystemProvider extends AbstractSshFileSystemProvider {
     private enum SupportedAttribute {
         creationTime("%W", "%B", FileTime.class),
         group("%G", "%Sg", GroupPrincipal.class),
-        fileKey("%i", "%i", Long.TYPE),
+        fileKey("%i", "%i", BigDecimal.class),
         lastAccessTime("%X", "%a", FileTime.class),
         lastModifiedTime("%Y", "%m", FileTime.class),
         lastChangedTime("%Z", "%c", FileTime.class),
@@ -909,6 +910,9 @@ public class UnixSshFileSystemProvider extends AbstractSshFileSystemProvider {
             }
             if ( valueClass == Long.TYPE ) {
                 return Long.parseLong( value );
+            }
+            if ( valueClass == BigDecimal.class ) {
+                return new BigDecimal( value );
             }
             if ( valueClass == FileTime.class ) {
                 long seconds = 0;


### PR DESCRIPTION
...on large Inode values.

Inode values can quickly grow large on cloud servers, causing the fileKey attribute check to fail when cast as a Long. To avoid this, I have updated the fileKey attribute type to BigDecimal.

... .... ...

java.lang.NumberFormatException: For input string: "12108003092091700687"
        at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
        at java.lang.Long.parseLong(Long.java:592)
        at java.lang.Long.parseLong(Long.java:631)
        at com.pastdev.jsch.nio.file.UnixSshFileSystemProvider$SupportedAttribute.toObject(UnixSshFileSystemProvider.java:911)
        at com.pastdev.jsch.nio.file.UnixSshFileSystemProvider.statParse(UnixSshFileSystemProvider.java:648)
        at com.pastdev.jsch.nio.file.UnixSshFileSystemProvider.readAttributes(UnixSshFileSystemProvider.java:541)
        at com.pastdev.jsch.nio.file.UnixSshFileSystemProvider.access$600(UnixSshFileSystemProvider.java:62)
        at com.pastdev.jsch.nio.file.UnixSshFileSystemProvider$BasicFileAttributesImpl.<init>(UnixSshFileSystemProvider.java:762)
        at com.pastdev.jsch.nio.file.UnixSshFileSystemProvider$BasicFileAttributesImpl.<init>(UnixSshFileSystemProvider.java:749)
        at com.pastdev.jsch.nio.file.UnixSshFileSystemProvider$BasicFileAttributesImpl.<init>(UnixSshFileSystemProvider.java:741)
        at com.pastdev.jsch.nio.file.UnixSshFileSystemProvider.readAttributes(UnixSshFileSystemProvider.java:498)
        at java.nio.file.Files.readAttributes(Files.java:1737)
        at java.nio.file.Files.isRegularFile(Files.java:2229)