### PR TITLE
FreeBSD should be treated as a BSD-based system along with Darwin

### DIFF
--- a/src/main/java/com/pastdev/jsch/nio/file/AbstractSshFileSystem.java
+++ b/src/main/java/com/pastdev/jsch/nio/file/AbstractSshFileSystem.java
@@ -109,6 +109,7 @@ public abstract class AbstractSshFileSystem extends FileSystem {
 
             switch ( execute.getStdout().trim().toLowerCase() ) {
                 case "darwin":
+                case "freebsd":
                     defaultVariant = Variant.BSD;
                     break;
                 default:


### PR DESCRIPTION
Hi! I've encountered some heavy problems using your library along with [CLion](https://www.jetbrains.com/clion/) if my target system is FreeBSD. As mentioned in the commit, FreeBSD should be treaded as a BSD-based system which is important, for example, for the `stat` command to be executed correctly. Also you should probably support other BSD-based systems such as NetBSD and OpenBSD.

Kind regards.